### PR TITLE
Fix train_step return type for scalar loss

### DIFF
--- a/configs/text_ours.yaml
+++ b/configs/text_ours.yaml
@@ -4,7 +4,7 @@ num_particles: 4
 
 # repulsive loss
 repulsion_type: "svgd" # "svgd" or "rlsd" or "wo"
-lambda_repulsion: 100 # weight for repulsive loss
+lambda_repulsion: 500 # weight for repulsive loss
 repulsion_tau: 0 # tau for repulsive loss (0: median bandwidth heuristic)
 kernel_type: "rbf" # "rbf" or "laplacian" -- to be added
 feature_layer: 6 # 0-2: early, 3-7: mid, 8-11: late

--- a/configs/text_ours_debug.yaml
+++ b/configs/text_ours_debug.yaml
@@ -29,59 +29,149 @@ debug_001:
   method: grid
   sweep_parameters:
     repulsion_type: ['svgd', 'rlsd', 'wo']  # Test all 3 methods quickly
-  
+
   fixed_parameters:
     seed: [42]                             # Single seed for speed
     prompts: ["a photo of a hamburger"]    # Simple prompt
     num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
     multi_view_type: ['average_views']
-    num_views: [2]                         # Ultra minimal views for debugging
-    repulsion_tau: [0]
-    lambda_sd: [1.0]
-    lambda_repulsion: [1]                # Single value
-    feature_layer: [6]                     # Single layer
-    kernel_type: ['rbf']
-    iters: [200]                            # Very short for debugging (~2-4 min per run)
-
-  settings:
-    visualize: true
-    save_iid: true
-    save_rendered_images_interval: 100      # Less frequent saves to reduce memory
-    save_multi_viewpoints_interval: 100     # Less frequent saves to reduce memory
-    metrics: true                         # Enable metrics to save memory
-    quantitative_metrics_interval: 50     # Less frequent metrics
-    losses_interval: 25                    # Less frequent for memory
-    efficiency_interval: 25               # Less frequent for memory
-
-debug_002:
-  name: svgd
-  method: grid
-  sweep_parameters:
-    repulsion_type: ['svgd']  # Test all 3 methods quickly
-  
-  fixed_parameters:
-    seed: [42]                             # Single seed for speed
-    prompts: ["a photo of a hamburger"]    # Simple prompt
-    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
-    multi_view_type: ['average_views']
-    num_views: [2]                         # Ultra minimal views for debugging
+    num_views: [4]                         # Ultra minimal views for debugging
     repulsion_tau: [0]
     lambda_sd: [1.0]
     lambda_repulsion: [100]                # Single value
     feature_layer: [6]                     # Single layer
     kernel_type: ['rbf']
-    iters: [200]                            # Very short for debugging (~2-4 min per run)
+    iters: [100]                                # Very short for debugging (~2-4 min per run)
+
+  settings:
+    visualize: true
+    save_iid: true
+    save_rendered_images_interval: 50      # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
+    metrics: true                         # Enable metrics to save memory
+    quantitative_metrics_interval: 10     # Less frequent metrics
+    losses_interval: 10                    # Less frequent for memory
+    efficiency_interval: 10           
+
+debug_002:
+  name: svgd
+  method: grid
+  sweep_parameters:
+    repulsion_type: ['svgd']  # Test svgd only
+  
+  fixed_parameters:
+    seed: [42]                             # Single seed for speed
+    prompts: ["a photo of a hamburger"]    # Simple prompt
+    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
+    multi_view_type: ['average_views']
+    num_views: [4]                         # Ultra minimal views for debugging
+    repulsion_tau: [0]
+    lambda_sd: [1.0]
+    lambda_repulsion: [100]                # Single value
+    feature_layer: [6]                     # Single layer
+    kernel_type: ['rbf']
+    iters: [100]                                # Very short for debugging (~2-4 min per run)
+
+  settings:
+    visualize: true
+    save_iid: true
+    save_rendered_images_interval: 50      # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
+    metrics: true                         # Enable metrics to save memory
+    quantitative_metrics_interval: 10     # Less frequent metrics
+    losses_interval: 10                    # Less frequent for memory
+    efficiency_interval: 10           
+
+debug_003:
+  name: rlsd
+  method: grid
+  sweep_parameters:
+    repulsion_type: ['rlsd']  # Test rlsd only
+  
+  fixed_parameters:
+    seed: [42]                             # Single seed for speed
+    prompts: ["a photo of a hamburger"]    # Simple prompt
+    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
+    multi_view_type: ['average_views']
+    num_views: [4]                         # Ultra minimal views for debugging
+    repulsion_tau: [0]
+    lambda_sd: [1.0]
+    lambda_repulsion: [100]                # Single value
+    feature_layer: [6]                     # Single layer
+    kernel_type: ['rbf']
+    iters: [100]                                # Very short for debugging (~2-4 min per run)
+
+  settings:
+    visualize: true
+    save_iid: true
+    save_rendered_images_interval: 50      # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
+    metrics: true                         # Enable metrics to save memory
+    quantitative_metrics_interval: 10     # Less frequent metrics
+    losses_interval: 10                    # Less frequent for memory
+    efficiency_interval: 10               # Less frequent for memory
+
+
+debug_004:
+  name: svgd_rlsd
+  method: grid
+  sweep_parameters:
+    repulsion_type: ['svgd', 'rlsd']  # Test rlsd only
+
+  fixed_parameters:
+    seed: [42]                             # Single seed for speed
+    prompts: ["a photo of a hamburger"]    # Simple prompt
+    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
+    multi_view_type: ['average_views']
+    num_views: [4]                         # Ultra minimal views for debugging
+    repulsion_tau: [0]
+    lambda_sd: [1.0]
+    lambda_repulsion: [1.0]                # Single value
+    feature_layer: [6]                     # Single layer
+    kernel_type: ['rbf']
+    iters: [300]                                # Very short for debugging (~2-4 min per run)
 
   settings:
     visualize: true
     save_iid: true
     save_rendered_images_interval: 100      # Less frequent saves to reduce memory
-    save_multi_viewpoints_interval: 100     # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
     metrics: true                         # Enable metrics to save memory
     quantitative_metrics_interval: 50     # Less frequent metrics
     losses_interval: 25                    # Less frequent for memory
     efficiency_interval: 25               # Less frequent for memory
 
+
+debug_005:
+  name: wo
+  method: grid
+  sweep_parameters:
+    repulsion_type: ['wo']  # Test rlsd only
+
+  fixed_parameters:
+    seed: [42]                             # Single seed for speed
+    prompts: ["a photo of a hamburger"]    # Simple prompt
+    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
+    multi_view_type: ['average_views']
+    num_views: [4]                         # Ultra minimal views for debugging
+    repulsion_tau: [0]
+    lambda_sd: [1.0]
+    lambda_repulsion: [1.0]                # Single value
+    feature_layer: [6]                     # Single layer
+    kernel_type: ['rbf']
+    iters: [300]                                # Very short for debugging (~2-4 min per run)
+
+  settings:
+    visualize: true
+    save_iid: true
+    save_rendered_images_interval: 100      # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
+    metrics: true                         # Enable metrics to save memory
+    quantitative_metrics_interval: 50     # Less frequent metrics
+    losses_interval: 25                    # Less frequent for memory
+    efficiency_interval: 25               # Less frequent for memory
+
+# ==================
 # ============================================================================
 # DEBUG CONFIGURATION COMPLETE
 # ============================================================================

--- a/configs/text_ours_debug.yaml
+++ b/configs/text_ours_debug.yaml
@@ -38,7 +38,7 @@ debug_001:
     num_views: [2]                         # Ultra minimal views for debugging
     repulsion_tau: [0]
     lambda_sd: [1.0]
-    lambda_repulsion: [100]                # Single value
+    lambda_repulsion: [1]                # Single value
     feature_layer: [6]                     # Single layer
     kernel_type: ['rbf']
     iters: [200]                            # Very short for debugging (~2-4 min per run)

--- a/configs/text_ours_debug.yaml
+++ b/configs/text_ours_debug.yaml
@@ -25,7 +25,7 @@
 #   Storage: ~20-40MB per run (3 runs ≈ 60-120MB total)
 #   Recommended SLURM: --time=00:30:00 --mem=16G --gres=gpu:1
 debug_001:
-  name: all_3_methods
+  name: svgd_rlsd_wo
   method: grid
   sweep_parameters:
     repulsion_type: ['svgd', 'rlsd', 'wo']  # Test all 3 methods quickly
@@ -33,25 +33,25 @@ debug_001:
   fixed_parameters:
     seed: [42]                             # Single seed for speed
     prompts: ["a photo of a hamburger"]    # Simple prompt
-    num_particles: [2]                     # Minimal particles for SVGD/RLSD (need >1)
+    num_particles: [4]                     # Minimal particles for SVGD/RLSD (need >1)
     multi_view_type: ['average_views']
-    num_views: [4]                         # Ultra minimal views for debugging
+    num_views: [8]                         # Ultra minimal views for debugging
     repulsion_tau: [0]
     lambda_sd: [1.0]
-    lambda_repulsion: [100]                # Single value
+    lambda_repulsion: [700]                # Single value
     feature_layer: [6]                     # Single layer
     kernel_type: ['rbf']
-    iters: [100]                                # Very short for debugging (~2-4 min per run)
+    iters: [1500]                                # Very short for debugging (~2-4 min per run)
 
   settings:
     visualize: true
     save_iid: true
-    save_rendered_images_interval: 50      # Less frequent saves to reduce memory
-    save_multi_viewpoints_interval: 300     # Less frequent saves to reduce memory
+    save_rendered_images_interval: 100      # Less frequent saves to reduce memory
+    save_multi_viewpoints_interval: 500     # Less frequent saves to reduce memory
     metrics: true                         # Enable metrics to save memory
-    quantitative_metrics_interval: 10     # Less frequent metrics
-    losses_interval: 10                    # Less frequent for memory
-    efficiency_interval: 10           
+    quantitative_metrics_interval: 50     # Less frequent metrics
+    losses_interval: 25                    # Less frequent for memory
+    efficiency_interval: 25           
 
 debug_002:
   name: svgd

--- a/guidance/sd_utils.py
+++ b/guidance/sd_utils.py
@@ -244,6 +244,8 @@ class StableDiffusion(nn.Module):
             pred_rgb_512 = F.interpolate(pred_rgb, (512, 512), mode="bilinear", align_corners=False)
             # encode image into latents with vae, requires grad!
             latents = self.encode_imgs(pred_rgb_512)
+            
+        assert latents.shape[1:] == (4, 64, 64), f"latents.shape: {latents.shape}"
 
         with torch.no_grad():
             if step_ratio is not None:

--- a/loss_utils.py
+++ b/loss_utils.py
@@ -3,57 +3,59 @@ import torch
 import torch.nn.functional as F
 
 @torch.no_grad()
-def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd"):
+def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd", device="cuda"):
     """
-    Compute RBF kernel matrix and its gradients.
-    
+    Compute RBF kernel matrix and gradient sums used in SVGD-like updates.
+
     Args:
-        features: [N, D] tensor of feature vectors
-        tau: kernel bandwidth
-        normalize: whether to normalize features
-    
+        features: [N, D] tensor (x_i)
+        tau: kernel bandwidth. If 0, use median heuristic on pairwise squared distances.
+        gradient_type: "svgd" or "rlsd"
+
     Returns:
-        K: [N, N] kernel matrix where K[i,j] = k(x_j, x_i)
-        K_grad: [N,  D_feature] kernel gradients where K_grad[i,j] = ∇_{x_j} (∑ over j k(x_j, x_i)) or ∇_{x_j} log(∑ over j k(x_j, x_i))
+        K: [N, N], where K[i,j] = k(x_i, x_j)
+        G: [N, D]
+           if gradient_type == "svgd":
+               G[i] = sum_j ∇_{x_i} k(x_i, x_j)          # wrt x_i
+           if gradient_type == "rlsd":
+               G[i] = ∇_{x_i} log( sum_j k(x_i, x_j) )
     """
-    N, D_feature = features.shape
-    
-    # Compute pairwise differences and squared distances
-    z_i = features.unsqueeze(1)  # [N, 1, D_feature]
-    z_j = features.unsqueeze(0)  # [1, N, D_feature]
-    
-    diffs = z_i - z_j  # [N, N, D_feature] where diffs[i,j] = z_i - z_j
-    sq_dists = (diffs ** 2).sum(-1)  # [N, N] # sq_dists[i,j] = ||z_i - z_j||^2
-    
-    if tau == 0: # if tau is 0, use median bandwidth heuristic
-        # Median bandwidth heuristic h = median(sq_dists) ** 2 / log(N)
-        # median = the median of the pairwise distances between particles
-        dists = sq_dists.sqrt() # [N, N] # pairwise distances between particles
-        median_dist = torch.median(dists) # [1] # median of pairwise distances between particles
-        h = median_dist ** 2 / torch.log(torch.tensor(N, dtype=torch.float32, device=features.device)) # [1] # h = median(dist) ** 2 / log(N)
+    features = features.to(device)
+    X = features  # [N, D]
+    N, D = X.shape
+
+    Xi = X.unsqueeze(1)  # [N,1,D]
+    Xj = X.unsqueeze(0)  # [1,N,D]
+    diffs = Xi - Xj      # [N,N,D]; diffs[i,j] = x_i - x_j
+    sq_dists = (diffs ** 2).sum(-1)  # [N,N]
+
+    if tau == 0:
+        # Median heuristic on squared distances (exclude diagonal)
+        with torch.no_grad():
+            mask = ~torch.eye(N, dtype=torch.bool, device=X.device)
+            med = torch.median(sq_dists[mask])
+            h = med / torch.log(torch.tensor(N + 1.0, device=X.device))
+            h = torch.clamp(h, min=1e-6)
     else:
-        h = tau ** 2 # if tau is not 0, use tau
-    
-    # RBF kernel k(z_i, z_j) = exp(-||z_i - z_j||^2 / h)
-    K = torch.exp(-sq_dists / h)  # [N, N]
-    
-    if repulsion_type == "svgd": # SVGD
-        # RBF kernel gradient ∇_{z_j} sum_j k(z_i, z_j) 
-        # = ∇_{z_j} (sum_j exp(-||z_i - z_j||^2 / h)
-        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j))
-        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
-        K_grad_sum_j = K_grad.sum(dim=1) # [N, D_feature] (sum over particles j)
-        return K, K_grad_sum_j # [N, N], [N, D_feature]
-    elif repulsion_type == "rlsd":   # smooth SVGD (RLSD)
-        # RBF kernel gradient ∇_{z_j} log( sum_j k(z_i, z_j) )
-        # = ∇_{z_j} (sum_j k(z_i, z_j)) / (sum_j k(z_i, z_j))
-        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j)) / (sum_j k(z_i, z_j))
-        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
-        K_sum_j = K.sum(dim=1) # [N] (sum over particles j)
-        K_grad_sum_j = K_grad.sum(dim=1) / K_sum_j.unsqueeze(-1) # [N, D_feature] / [N, 1] -> [N, D_feature] (sum over particles j)  # ∇_{z_j} log(∑ over j k(z_i, z_j))
-        return K, K_grad_sum_j # [N, N], [N, D_feature]
+        h = torch.tensor(tau**2, device=X.device, dtype=X.dtype)
+
+    K = torch.exp(-sq_dists / h)  # [N,N], K[i,j] = k(x_i,x_j)
+
+    if repulsion_type == "svgd":
+        # ∇_{x_i} k(x_i,x_j) = -(2/h) (x_i - x_j) k
+        G = -(2.0 / h) * (K.unsqueeze(-1) * diffs).sum(dim=1)  # [N,D], sum over j
+        return K, G
+
+    elif repulsion_type == "rlsd":
+        # ∇_{x_i} log( sum_j k(x_i,x_j) ) = (sum_j ∇_{x_i}k) / (sum_j k)
+        num = -(2.0 / h) * (K.unsqueeze(-1) * diffs).sum(dim=1)   # [N,D]
+        den = K.sum(dim=1, keepdim=True).clamp_min(1e-9)          # [N,1]
+        G = num / den                                             # [N,D]
+        return K, G
+
     else:
-        raise ValueError("Invalid kernel gradient type")
+        raise ValueError("gradient_type must be 'svgd' or 'rlsd'")
+
 
 if __name__ == "__main__":
     N, D = 4, 128

--- a/loss_utils.py
+++ b/loss_utils.py
@@ -2,59 +2,58 @@
 import torch
 import torch.nn.functional as F
 
-def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd", device="cuda"):
+@torch.no_grad()
+def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd"):
     """
-    Compute RBF kernel matrix and gradient sums used in SVGD-like updates.
-
+    Compute RBF kernel matrix and its gradients.
+    
     Args:
-        features: [N, D] tensor (x_i)
-        tau: kernel bandwidth. If 0, use median heuristic on pairwise squared distances.
-        gradient_type: "svgd" or "rlsd"
-
+        features: [N, D] tensor of feature vectors
+        tau: kernel bandwidth
+        normalize: whether to normalize features
+    
     Returns:
-        K: [N, N], where K[i,j] = k(x_i, x_j)
-        G: [N, D]
-           if gradient_type == "svgd":
-               G[i] = sum_j ∇_{x_i} k(x_i, x_j)          # wrt x_i
-           if gradient_type == "rlsd":
-               G[i] = ∇_{x_i} log( sum_j k(x_i, x_j) )
+        K: [N, N] kernel matrix where K[i,j] = k(x_j, x_i)
+        K_grad: [N,  D_feature] kernel gradients where K_grad[i,j] = ∇_{x_j} (∑ over j k(x_j, x_i)) or ∇_{x_j} log(∑ over j k(x_j, x_i))
     """
-    features = features.to(device)
-    X = features  # [N, D]
-    N, D = X.shape
-
-    Xi = X.unsqueeze(1)  # [N,1,D]
-    Xj = X.unsqueeze(0)  # [1,N,D]
-    diffs = Xi - Xj      # [N,N,D]; diffs[i,j] = x_i - x_j
-    sq_dists = (diffs ** 2).sum(-1)  # [N,N]
-
-    if tau == 0:
-        # Median heuristic on squared distances (exclude diagonal)
-        with torch.no_grad():
-            mask = ~torch.eye(N, dtype=torch.bool, device=X.device)
-            med = torch.median(sq_dists[mask])
-            h = med / torch.log(torch.tensor(N + 1.0, device=X.device))
-            h = torch.clamp(h, min=1e-6)
+    N, D_feature = features.shape
+    
+    # Compute pairwise differences and squared distances
+    z_i = features.unsqueeze(1)  # [N, 1, D_feature]
+    z_j = features.unsqueeze(0)  # [1, N, D_feature]
+    
+    diffs = z_i - z_j  # [N, N, D_feature] where diffs[i,j] = z_i - z_j
+    sq_dists = (diffs ** 2).sum(-1)  # [N, N] # sq_dists[i,j] = ||z_i - z_j||^2
+    
+    if tau == 0: # if tau is 0, use median bandwidth heuristic
+        # Median bandwidth heuristic h = median(sq_dists) ** 2 / log(N)
+        # median = the median of the pairwise distances between particles
+        dists = sq_dists.sqrt() # [N, N] # pairwise distances between particles
+        median_dist = torch.median(dists) # [1] # median of pairwise distances between particles
+        h = median_dist ** 2 / torch.log(torch.tensor(N, dtype=torch.float32, device=features.device)) # [1] # h = median(dist) ** 2 / log(N)
     else:
-        h = torch.tensor(tau**2, device=X.device, dtype=X.dtype)
-
-    K = torch.exp(-sq_dists / h)  # [N,N], K[i,j] = k(x_i,x_j)
-
-    if repulsion_type == "svgd":
-        # ∇_{x_i} k(x_i,x_j) = -(2/h) (x_i - x_j) k
-        G = -(2.0 / h) * (K.unsqueeze(-1) * diffs).sum(dim=1)  # [N,D], sum over j
-        return K, G
-
-    elif repulsion_type == "rlsd":
-        # ∇_{x_i} log( sum_j k(x_i,x_j) ) = (sum_j ∇_{x_i}k) / (sum_j k)
-        num = -(2.0 / h) * (K.unsqueeze(-1) * diffs).sum(dim=1)   # [N,D]
-        den = K.sum(dim=1, keepdim=True).clamp_min(1e-9)          # [N,1]
-        G = num / den                                             # [N,D]
-        return K, G
-
+        h = tau ** 2 # if tau is not 0, use tau
+    
+    # RBF kernel k(z_i, z_j) = exp(-||z_i - z_j||^2 / h)
+    K = torch.exp(-sq_dists / h)  # [N, N]
+    
+    if gradient_type == "svgd": # SVGD
+        # RBF kernel gradient ∇_{z_j} sum_j k(z_i, z_j) 
+        # = ∇_{z_j} (sum_j exp(-||z_i - z_j||^2 / h)
+        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j))
+        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+        K_grad_sum_j = K_grad.sum(dim=1) # [N, D_feature] (sum over particles j)
+        return K, K_grad_sum_j # [N, N], [N, D_feature]
+    elif gradient_type == "rlsd":   # smooth SVGD (RLSD)
+        # RBF kernel gradient ∇_{z_j} log( sum_j k(z_i, z_j) )
+        # = ∇_{z_j} (sum_j k(z_i, z_j)) / (sum_j k(z_i, z_j))
+        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j)) / (sum_j k(z_i, z_j))
+        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+        K_sum_j = K.sum(dim=1) # [N] (sum over particles j)
+        K_grad_sum_j = K_grad.sum(dim=1) / K_sum_j.unsqueeze(-1) # [N, D_feature] / [N, 1] -> [N, D_feature] (sum over particles j)  # ∇_{z_j} log(∑ over j k(z_i, z_j))
+        return K, K_grad_sum_j # [N, N], [N, D_feature]
     else:
-        raise ValueError("gradient_type must be 'svgd' or 'rlsd'")
-
+        raise ValueError("Invalid kernel gradient type")
 
 if __name__ == "__main__":
     N, D = 4, 128
@@ -64,8 +63,8 @@ if __name__ == "__main__":
     print(f"\nFeature norms - min: {torch.norm(features, dim=1).min():.4f}, max: {torch.norm(features, dim=1).max():.4f}")
     
     for tau in [0.0, 0.5, 1.0, 2.0]:
-        for repulsion_type in ["svgd", "rlsd"]:
-            K, K_grad_sum_j = rbf_kernel_and_grad(features, tau=tau, repulsion_type=repulsion_type)
+        for gradient_type in ["svgd", "rlsd"]:
+            K, K_grad_sum_j = rbf_kernel_and_grad(features, tau=tau, gradient_type=gradient_type)
             print(f"\nKernel matrix:")
             print(K)
             print(f"\nKernel gradient sum over j:")

--- a/loss_utils.py
+++ b/loss_utils.py
@@ -10,48 +10,74 @@ def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd"):
     Args:
         features: [N, D] tensor of feature vectors
         tau: kernel bandwidth
-        repulsion_type: "svgd" or "rlsd"
+        normalize: whether to normalize features
     
     Returns:
         K: [N, N] kernel matrix where K[i,j] = k(x_j, x_i)
         K_grad: [N,  D_feature] kernel gradients where K_grad[i,j] = ∇_{x_j} (∑ over j k(x_j, x_i)) or ∇_{x_j} log(∑ over j k(x_j, x_i))
     """
+    # N, D_feature = features.shape
+    
+    # # Compute pairwise differences and squared distances
+    # z_i = features.unsqueeze(1)  # [N, 1, D_feature]
+    # z_j = features.unsqueeze(0)  # [1, N, D_feature]
+    
+    # diffs = z_i - z_j  # [N, N, D_feature] where diffs[i,j] = z_i - z_j
+    # sq_dists = (diffs ** 2).sum(-1)  # [N, N] # sq_dists[i,j] = ||z_i - z_j||^2
+    
+    # if tau == 0: # if tau is 0, use median bandwidth heuristic
+    #     # Median bandwidth heuristic h = median(sq_dists) ** 2 / log(N)
+    #     # median = the median of the pairwise distances between particles
+    #     dists = sq_dists.sqrt() # [N, N] # pairwise distances between particles
+    #     median_dist = torch.median(dists) # [1] # median of pairwise distances between particles
+    #     h = median_dist ** 2 / torch.log(torch.tensor(N, dtype=torch.float32, device=features.device)) # [1] # h = median(dist) ** 2 / log(N)
+        
+    # else:
+    #     h = tau ** 2 # if tau is not 0, use tau
+    
+    # # RBF kernel k(z_i, z_j) = exp(-||z_i - z_j||^2 / h)
+    # K = torch.exp(-sq_dists / h)  # [N, N]
+    
+    # if repulsion_type == "svgd": # SVGD
+    #     # RBF kernel gradient ∇_{z_j} sum_j k(z_i, z_j) 
+    #     # = ∇_{z_j} (sum_j exp(-||z_i - z_j||^2 / h)
+    #     # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j))
+    #     K_grad = -(2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+    #     K_grad_sum_j = K_grad.sum(dim=1) # [N, D_feature] (sum over particles j)
+    #     return K, K_grad_sum_j # [N, N], [N, D_feature]
+    # elif repulsion_type == "rlsd":   # smooth SVGD (RLSD)
+    #     # RBF kernel gradient ∇_{z_j} log( sum_j k(z_i, z_j) )
+    #     # = ∇_{z_j} (sum_j k(z_i, z_j)) / (sum_j k(z_i, z_j))
+    #     # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j)) / (sum_j k(z_i, z_j))
+    #     K_grad = -(2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+    #     K_sum_j = K.sum(dim=1) # [N] (sum over particles j)
+    #     K_grad_sum_j = K_grad.sum(dim=1) / K_sum_j.unsqueeze(-1) # [N, D_feature] / [N, 1] -> [N, D_feature] (sum over particles j)  # ∇_{z_j} log(∑ over j k(z_i, z_j))
+    #     return K, K_grad_sum_j # [N, N], [N, D_feature]
+    
+    # exclude diagonal when computing the median bandwidth; clamp h and denom
     N, D_feature = features.shape
-    
-    # Compute pairwise differences and squared distances
-    z_i = features.unsqueeze(1)  # [N, 1, D_feature]
-    z_j = features.unsqueeze(0)  # [1, N, D_feature]
-    
-    diffs = z_i - z_j  # [N, N, D_feature] where diffs[i,j] = z_i - z_j
-    sq_dists = (diffs ** 2).sum(-1)  # [N, N] # sq_dists[i,j] = ||z_i - z_j||^2
-    
-    if tau == 0: # if tau is 0, use median bandwidth heuristic
-        # Median bandwidth heuristic h = median(sq_dists) ** 2 / log(N)
-        # median = the median of the pairwise distances between particles
-        dists = sq_dists.sqrt() # [N, N] # pairwise distances between particles
-        median_dist = torch.median(dists) # [1] # median of pairwise distances between particles
-        h = median_dist ** 2 / torch.log(torch.tensor(N, dtype=torch.float32, device=features.device)) # [1] # h = median(dist) ** 2 / log(N)
+    z_i = features.unsqueeze(1)
+    z_j = features.unsqueeze(0)
+    diffs = z_i - z_j
+    sq_dists = (diffs ** 2).sum(-1)  # [N,N]
+
+    if tau == 0:
+        mask = ~torch.eye(N, dtype=torch.bool, device=features.device)
+        med = torch.median(sq_dists[mask])
+        h = (med / torch.log(torch.tensor(N + 1.0, device=features.device))).clamp_min(1e-6)
     else:
-        h = tau ** 2 # if tau is not 0, use tau
-    
-    # RBF kernel k(z_i, z_j) = exp(-||z_i - z_j||^2 / h)
-    K = torch.exp(-sq_dists / h)  # [N, N]
-    
-    if repulsion_type == "svgd": # SVGD
-        # RBF kernel gradient ∇_{z_j} sum_j k(z_i, z_j) 
-        # = ∇_{z_j} (sum_j exp(-||z_i - z_j||^2 / h)
-        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j))
-        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
-        K_grad_sum_j = K_grad.sum(dim=1) # [N, D_feature] (sum over particles j)
-        return K, K_grad_sum_j # [N, N], [N, D_feature]
-    elif repulsion_type == "rlsd":   # smooth SVGD (RLSD)
-        # RBF kernel gradient ∇_{z_j} log( sum_j k(z_i, z_j) )
-        # = ∇_{z_j} (sum_j k(z_i, z_j)) / (sum_j k(z_i, z_j))
-        # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j)) / (sum_j k(z_i, z_j))
-        K_grad = (2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
-        K_sum_j = K.sum(dim=1) # [N] (sum over particles j)
-        K_grad_sum_j = K_grad.sum(dim=1) / K_sum_j.unsqueeze(-1) # [N, D_feature] / [N, 1] -> [N, D_feature] (sum over particles j)  # ∇_{z_j} log(∑ over j k(z_i, z_j))
-        return K, K_grad_sum_j # [N, N], [N, D_feature]
+        h = torch.tensor(tau**2, device=features.device, dtype=features.dtype).clamp_min(1e-12)
+
+    K = torch.exp(-sq_dists / h)  # keep diagonal; it stabilizes sums
+
+    # sign of K_grad is opposite to the original paper
+    if repulsion_type == "svgd":
+        K_grad = (2 / h) * K.unsqueeze(-1) * diffs
+        return K, K_grad.sum(dim=1)
+    elif repulsion_type == "rlsd":
+        K_grad = (2 / h) * K.unsqueeze(-1) * diffs
+        K_sum = K.sum(dim=1, keepdim=True).clamp_min(1e-9)  # avoid 0/0
+        return K, K_grad.sum(dim=1) / K_sum
     else:
         raise ValueError("Invalid kernel gradient type")
 
@@ -65,7 +91,118 @@ if __name__ == "__main__":
     for tau in [0.0, 0.5, 1.0, 2.0]:
         for repulsion_type in ["svgd", "rlsd"]:
             K, K_grad_sum_j = rbf_kernel_and_grad(features, tau=tau, repulsion_type=repulsion_type)
-            print(f"\nKernel matrix:")
+            print(f"\nKernel matrix:")  
             print(K)
             print(f"\nKernel gradient sum over j:")
             print(K_grad_sum_j)
+
+
+########################################################
+# # loss_utils.py
+# import torch
+# import torch.nn.functional as F
+
+# def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd"):
+#     X = features
+#     N, D = X.shape
+#     Xi = X.unsqueeze(1)            # [N,1,D]
+#     Xj = X.unsqueeze(0)            # [1,N,D]
+#     diffs = Xi - Xj                # [N,N,D]
+#     sq = (diffs**2).sum(-1)        # [N,N]
+#     if tau == 0:
+#         mask = ~torch.eye(N, dtype=torch.bool, device=X.device)
+#         med = torch.median(sq[mask])
+#         h = (med / torch.log(torch.tensor(N+1.0, device=X.device))).clamp_min(1e-6)
+#     else:
+#         h = torch.tensor(tau**2, device=X.device, dtype=X.dtype)
+
+#     K = torch.exp(-sq / h)         # define: K[i,j] = k(x_i, x_j)
+#     eye = torch.eye(N, device=X.device, dtype=X.dtype)
+#     K = K * (1 - eye)
+    
+#     G_i = (-(2.0 / h)) * (K.unsqueeze(-1) * diffs).sum(dim=1)  # [N,D], sum over j
+
+#     if repulsion_type == "svgd":
+#         return K, G_i
+#     elif repulsion_type == "rlsd":
+#         den = K.sum(dim=1, keepdim=True).clamp_min(1e-9)           # [N,1]
+#         return K, G_i / den
+#     else:
+#         raise ValueError("repulsuion_type must be 'svgd' or 'rlsd'")
+
+
+
+
+
+########################
+# # loss_utils.py
+# import torch
+# import torch.nn.functional as F
+
+# def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd"):
+#     """
+#     Compute RBF kernel matrix and its gradients.
+    
+#     Args:
+#         features: [N, D] tensor of feature vectors
+#         tau: kernel bandwidth
+#         normalize: whether to normalize features
+    
+#     Returns:
+#         K: [N, N] kernel matrix where K[i,j] = k(x_j, x_i)
+#         K_grad: [N,  D_feature] kernel gradients where K_grad[i,j] = ∇_{x_j} (∑ over j k(x_j, x_i)) or ∇_{x_j} log(∑ over j k(x_j, x_i))
+#     """
+#     N, D_feature = features.shape
+    
+#     # Compute pairwise differences and squared distances
+#     z_i = features.unsqueeze(1)  # [N, 1, D_feature]
+#     z_j = features.unsqueeze(0)  # [1, N, D_feature]
+    
+#     diffs = z_i - z_j  # [N, N, D_feature] where diffs[i,j] = z_i - z_j
+#     sq_dists = (diffs ** 2).sum(-1)  # [N, N] # sq_dists[i,j] = ||z_i - z_j||^2
+    
+#     if tau == 0: # if tau is 0, use median bandwidth heuristic
+#         # Median bandwidth heuristic h = median(sq_dists) ** 2 / log(N)
+#         # median = the median of the pairwise distances between particles
+#         mask = ~torch.eye(N, dtype=torch.bool, device=features.device)
+#         med = torch.median(sq_dists[mask])
+#         h = (med / torch.log(torch.tensor(N+1.0, device=features.device))).clamp_min(1e-6)
+#     else:
+#         h = torch.tensor(tau**2, device=features.device, dtype=features.dtype) # if tau is not 0, use tau
+
+#     # RBF kernel k(z_i, z_j) = exp(-||z_i - z_j||^2 / h)
+#     K = torch.exp(-sq_dists / h)  # [N, N]
+#     K = K * (1 - torch.eye(N, device=features.device, dtype=features.dtype)) # mask out diagonal elements
+
+#     if repulsion_type == "svgd": # SVGD
+#         # RBF kernel gradient ∇_{z_j} sum_j k(z_i, z_j) 
+#         # = ∇_{z_j} (sum_j exp(-||z_i - z_j||^2 / h)
+#         # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j))
+#         K_grad = -(2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+#         K_grad_sum_j = K_grad.sum(dim=1) # [N, D_feature] (sum over particles j)
+#         return K, K_grad_sum_j # [N, N], [N, D_feature]
+#     elif repulsion_type == "rlsd":   # smooth SVGD (RLSD)
+#         # RBF kernel gradient ∇_{z_j} log( sum_j k(z_i, z_j) )
+#         # = ∇_{z_j} (sum_j k(z_i, z_j)) / (sum_j k(z_i, z_j))
+#         # = sum_j ((2/h) * (z_i - z_j) * k(z_i, z_j)) / (sum_j k(z_i, z_j))
+#         K_grad = -(2 / h) * K.unsqueeze(-1) * diffs  # [N, N, 1] *  [N, N, D_feature] / h # [N, N, D_feature]
+#         K_sum_j = K.sum(dim=1) # [N] (sum over particles j)
+#         K_grad_sum_j = K_grad.sum(dim=1) / K_sum_j.unsqueeze(-1) # [N, D_feature] / [N, 1] -> [N, D_feature] (sum over particles j)  # ∇_{z_j} log(∑ over j k(z_i, z_j))
+#         return K, K_grad_sum_j # [N, N], [N, D_feature]
+#     else:
+#         raise ValueError("Invalid kernel gradient type")
+
+# if __name__ == "__main__":
+#     N, D = 4, 128
+#     features = torch.randn(N, D) # [N, D]
+#     print("Original features:")
+#     print(features)
+#     print(f"\nFeature norms - min: {torch.norm(features, dim=1).min():.4f}, max: {torch.norm(features, dim=1).max():.4f}")
+    
+#     for tau in [0.0, 0.5, 1.0, 2.0]:
+#         for repulsion_type in ["svgd", "rlsd"]:
+#             K, K_grad_sum_j = rbf_kernel_and_grad(features, tau=tau, repulsion_type=repulsion_type)
+#             print(f"\nKernel matrix:")
+#             print(K)
+#             print(f"\nKernel gradient sum over j:")
+#             print(K_grad_sum_j)

--- a/loss_utils.py
+++ b/loss_utils.py
@@ -2,7 +2,6 @@
 import torch
 import torch.nn.functional as F
 
-@torch.no_grad()
 def rbf_kernel_and_grad(features, tau=0.5, repulsion_type="svgd", device="cuda"):
     """
     Compute RBF kernel matrix and gradient sums used in SVGD-like updates.

--- a/main_ours.py
+++ b/main_ours.py
@@ -84,7 +84,7 @@ class GUI:
         # override if provide a checkpoint
         for i in range(self.opt.num_particles):
             # Set different seed for each particle during initialization
-            init_seed = self.seed + i * self.opt.iters # 42, 42 + 1500, 42 + 2 * 1500, 42 + 3 * 1500, 42 + 4 * 1500
+            init_seed = self.seed + i * self.opt.iters
             self.seeds.append(init_seed)
             self.seed_everything(init_seed)
             
@@ -95,7 +95,7 @@ class GUI:
                 self.renderers[i].initialize(num_pts=self.opt.num_pts)
                 
         # visualizer
-        if self.opt.visualize or self.opt.metrics:
+        if self.opt.visualize:
             self.visualizer = GaussianVisualizer(opt=self.opt, renderers=self.renderers, cam=self.cam)
         else:
             self.visualizer = None
@@ -144,7 +144,6 @@ class GUI:
             model_name=self.opt.feature_extractor_model_name, 
             device=self.device
         )
-        
         # metrics
         if self.opt.metrics:
             self.metrics_calculator = MetricsCalculator(opt=self.opt, prompt=self.prompt, multi_view_type=self.opt.multi_view_type)
@@ -171,7 +170,7 @@ class GUI:
         self.step += 1
         step_ratio = min(1, self.step / self.opt.iters)
 
-
+        total_loss = 0
 
         ### novel view (manual batch)
         render_resolution = 128 if step_ratio < 0.3 else (256 if step_ratio < 0.6 else 512)
@@ -186,7 +185,7 @@ class GUI:
         for j in range(self.opt.num_particles):
             
             # set seed for each particle + iteration step for different viewpoints each iter
-            self.seed_everything(self.seeds[j] + self.step - 1) # 42 , 42 + 1, 42 + 2, 42 + 3, ..., 42 + 1499
+            self.seed_everything(self.seeds[j] + self.step)
             # update lr
             self.renderers[j].gaussians.update_learning_rate(self.step)
 
@@ -212,89 +211,62 @@ class GUI:
             
             # Store output for each particle
             outputs.append(out)
-            
+                
         images = torch.cat(images, dim=0) # [N, 3, H, W]
         # poses = torch.from_numpy(np.stack(poses, axis=0)).to(self.device) # TODO: Check if this is correct
         
         features = self.feature_extractor.extract_cls_from_layer(self.opt.feature_layer, images).to(self.device) # [N, D_feature]
-
-
-        # --- before the branch, init for logging ---
-        total_loss = 0
-        attraction_loss = None
-        repulsion_loss = None
-        scaled_attraction_loss = None
-        scaled_repulsion_loss = None
-
-        # --- SVGD loss computation (루프 밖, 모든 파티클 동시에) ---
-        if self.opt.repulsion_type == 'svgd':
-            # 1. Score gradients from SD guidance
-            score_grad, sigma_t = self.guidance_sd.train_step_for_svgd_repulsion(
-                images, 
-                step_ratio=step_ratio if self.opt.anneal_timestep else None
-            )  # score_grad: [N, D_latent]
+        
+        # score matching regulizers (sds_loss) - computed without gradients
+        if self.opt.repulsion_type == 'rlsd':  
+            sds_loss = self.guidance_sd.train_step_for_rlsd_repulsion(images, step_ratio=step_ratio if self.opt.anneal_timestep else None) # [1]
             
-            score_grad = score_grad.to(features.dtype) # [N, D_latent]
-
-            # 2. Kernel & grad wrt xi (∑_j ∇_{xi} k(xi, xj))
-            K, G_wrt_xi = rbf_kernel_and_grad(
-                features, 
-                tau=self.opt.repulsion_tau, 
-                repulsion_type=self.opt.repulsion_type
-            )  # K:[N,N], G:[N,D_feature]   
-
-            # 3. Attraction: (1/N) * sum_i sum_j K[j,i] * score_grad[j]
-            #    K[i,j] = k(xi, xj) -> transpose해서 K[j,i]
-            # attraction_loss = (K.t().unsqueeze(-1) * score_grad.unsqueeze(0)).sum(dim=1).mean()
-            # attraction_loss = (K.t() @ score_grad).mean()
-            # attraction_loss = (K.t().mm(score_grad)).norm(dim=1).mean()
-            # attraction_loss = (K.t().mm(score_grad)).mean()
-            attraction_vector = (K.t().mm(score_grad)) / self.opt.num_particles # [N, D_latent]
-            attraction_loss = attraction_vector.norm(dim=1).mean() # [1] l2 norm of the attraction vector
-
-            # 4. Repulsion: (1/N) * sum_i sum_j ∇_{x_j}k(x_j,x_i)
-            #    대칭커널이면 ∇_{x_j}k(x_j,x_i) = -∇_{x_i}k(x_i,x_j)
-            rep_vector = -G_wrt_xi / self.opt.num_particles # [N,D_feature]
-            repulsion_loss = rep_vector.norm(dim=1).mean() # [1] l2 norm of the repulsion vector
+            # 2. RBF kernel gradient wrt features
+            rbf_kernel, rbf_kernel_log_grad = rbf_kernel_and_grad(features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type) # [N, N], [N, D_feature] 
             
+            # 3. Attraction loss (SDS) + 1/D_latent
+            attraction_loss = sds_loss # [1]
+            
+            # 4. Repulsion loss (Repulsion)
+            repulsion_loss = (rbf_kernel_log_grad * features).sum(dim=1).mean() # [N, D_feature] * [N, D_feature] -> [N] -> [1]
+            # repulsion_loss = torch.einsum('nd,nd->n', rbf_kernel_log_grad, features).mean()
             scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
-            scaled_repulsion_loss = self.opt.lambda_repulsion * sigma_t * repulsion_loss
-            # 5. Total loss
+            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
+                    
+        elif self.opt.repulsion_type == 'svgd':
+            score_gradients = self.guidance_sd.train_step_for_svgd_repulsion(images, step_ratio=step_ratio if self.opt.anneal_timestep else None) # [N, D_latent], [1]
             
-            # print("features.requires_grad:", features.requires_grad)  # True if gradient is computed
-            # print("features.grad_fn:", features.grad_fn)              # grad_fn is None if no gradient is computed
-
-
-        elif self.opt.repulsion_type == 'rlsd':
-            sds_loss, sigma_t = self.guidance_sd.train_step_for_rlsd_repulsion(
-                images, 
-                step_ratio=step_ratio if self.opt.anneal_timestep else None
-            )
-            K, G_rlsd = rbf_kernel_and_grad(
-                features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type
-            )
+            # 2. RBF kernel computation
+            rbf_kernel, rbf_kernel_grad = rbf_kernel_and_grad(features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type) # [N, N], [N, D_feature] 
             
-            attraction_loss = sds_loss
-            repulsion_loss = G_rlsd.norm(dim=1).mean()
-            scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
-            scaled_repulsion_loss = self.opt.lambda_repulsion * sigma_t *  repulsion_loss
+            # 3. Attraction loss: 1/N * sum_j k(xj, xi) * ∇_xj log p(xj)
+            # rbf_kernel: [N, N] where rbf_kernel[i,j] = k(xj, xi)
+            # score_gradients: [N] where score_gradients[j] = ∇_xj log p(xj)
+            # Multiply kernel matrix with score gradients: [N, N] * [N] -> [N] (sum over j for each i)
+            # 1/D_latent
+            attraction_per_particle = (rbf_kernel * score_gradients.unsqueeze(0)).sum(dim=1) # [N]
+            attraction_loss = attraction_per_particle.mean() # [1]
             
+            # # 3. Attraction loss: 1/N * sum_j k(xj, xi) * ∇_xj log p(xj)
+            # weighted_grad = rbf_kernel @ score_gradients  # [N, D_latent]
+            # attraction_loss = weighted_grad.norm(dim=1).mean()  # optional scalar for loss tracking
+            
+            # 4. Repulsion loss (same as before)
+            repulsion_loss = (rbf_kernel_grad * features).sum(dim=1).mean() # [N, D_feature] * [N, D_feature] -> [N] -> [1]
+            # [Question] should we divide by num_particles (mean)? in SVGD paper, they did divide by num_particles (mean)                              
+        
+            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
+            scaled_attraction_loss = self.opt.lambda_sd * attraction_loss 
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
-
-        elif self.opt.repulsion_type == 'wo':
-            # baseline
-            attraction_loss = self.guidance_sd.train_step_for_baseline(
-                images, step_ratio=step_ratio if self.opt.anneal_timestep else None
-            )
+        else:
+            attraction_loss = self.guidance_sd.train_step_for_baseline(images, step_ratio=step_ratio if self.opt.anneal_timestep else None) # [1] -> [1]
             repulsion_loss = torch.tensor(0.0, device=images.device)
+            
             scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
             scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
             
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
-            
-        else:
-            raise ValueError(f"[ERROR] Invalid repulsion type: {self.opt.repulsion_type}")
 
         ### optimize step ### 
         
@@ -323,7 +295,7 @@ class GUI:
         for j in range(self.opt.num_particles):
             self.optimizers[j].zero_grad()
         
-        # --- logging & visualization ---
+        # log metrics and visualize
         with torch.no_grad():
             if self.opt.metrics and self.metrics_calculator is not None:
                 # time
@@ -334,9 +306,23 @@ class GUI:
                 # memory usage
                 memory_allocated = torch.cuda.memory_allocated() / (1024 ** 2)  # Convert to MB
                 max_memory_allocated = torch.cuda.max_memory_allocated() / (1024 ** 2)  # Convert to MB
-
-                # quantitative metrics (guard visualizer)
-                if self.visualizer is not None:
+                
+                # losses
+                if self.opt.repulsion_type == 'rlsd' or self.opt.repulsion_type == 'svgd':
+                    attraction_loss_val = attraction_loss.item()
+                    repulsion_loss_val = repulsion_loss.item()
+                    scaled_attraction_loss_val = attraction_loss_val * self.opt.lambda_sd
+                    scaled_repulsion_loss_val = repulsion_loss_val * self.opt.lambda_repulsion
+                else:
+                    attraction_loss_val = 0
+                    repulsion_loss_val = 0
+                    scaled_attraction_loss_val = 0
+                    scaled_repulsion_loss_val = 0
+                    
+                total_loss_val = total_loss.item()
+            
+                # quantitative metrics
+                if self.opt.metrics and self.metrics_calculator is not None and self.visualizer is not None:
                     multi_view_images = self.visualizer.visualize_all_particles_in_multi_viewpoints(
                         self.step, num_views=self.opt.num_views, visualize=False, save_iid=False
                     )  # [V, N, 3, H, W]
@@ -346,26 +332,27 @@ class GUI:
                     diversity = float(self.metrics_calculator.compute_rlsd_diversity(rep_features))
                 else:
                     fidelity, diversity = 0.0, 0.0  # or skip logging these
-
+                    
+                # log
                 self.metrics_calculator.log_metrics(
                     step=self.step,
                     diversity=diversity,
                     fidelity=fidelity,
-                    attraction_loss=attraction_loss,
-                    repulsion_loss=repulsion_loss,
-                    scaled_attraction_loss=scaled_attraction_loss,
-                    scaled_repulsion_loss=scaled_repulsion_loss,
-                    total_loss=total_loss,
+                    attraction_loss=attraction_loss_val,
+                    repulsion_loss=repulsion_loss_val,
+                    scaled_attraction_loss=scaled_attraction_loss_val,
+                    scaled_repulsion_loss=scaled_repulsion_loss_val,
+                    total_loss=total_loss_val,
                     time=t,
                     memory_allocated_mb=memory_allocated,
                     max_memory_allocated_mb=max_memory_allocated,
                 )
-                
             # visualize
             if self.opt.visualize and self.visualizer is not None:
                 # save rendered images (save at the end of each interval)
                 if self.step % self.opt.save_rendered_images_interval == 0:
                     self.visualizer.save_rendered_images(self.step, images)
+                    # self.visualizer.visualize_all_particles_in_multi_viewpoints(self.step, num_views=4, save_iid=True) 
 
     @torch.no_grad()
     def save_model(self, mode='geo', texture_size=1024, particle_id=0):
@@ -512,9 +499,9 @@ class GUI:
             for j in range(self.opt.num_particles):
                 self.renderers[j].gaussians.prune(min_opacity=0.01, extent=1, max_screen_size=1)
     
-        # # Multi-viewpoints for 30 fps video (save at the end of training)
-        # if self.step == self.opt.iters and self.visualizer is not None and self.opt.visualize:
-        #     self.visualizer.visualize_all_particles_in_multi_viewpoints(self.step, num_views=120, save_iid=False) # 360 / 120 for 30 fps
+        # Multi-viewpoints for 30 fps video (save at the end of training)
+        if self.step == self.opt.iters:
+            self.visualizer.visualize_all_particles_in_multi_viewpoints(self.step, num_views=120, save_iid=True) # 360 / 120 for 30 fps
 
         # save model
         for j in range(self.opt.num_particles):

--- a/main_ours.py
+++ b/main_ours.py
@@ -262,8 +262,8 @@ class GUI:
             # 5. Total loss
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
             
-            print("features.requires_grad:", features.requires_grad)  # True 여야 함
-            print("features.grad_fn:", features.grad_fn)              # None 이면 끊긴 것
+            # print("features.requires_grad:", features.requires_grad)  # True if gradient is computed
+            # print("features.grad_fn:", features.grad_fn)              # grad_fn is None if no gradient is computed
 
 
         elif self.opt.repulsion_type == 'rlsd':

--- a/main_ours.py
+++ b/main_ours.py
@@ -223,64 +223,64 @@ class GUI:
         total_loss = 0
         attraction_loss = None
         repulsion_loss = None
-        sigma_t = 1.0  # default
-        
+        scaled_attraction_loss = None
+        scaled_repulsion_loss = None
+
         # --- SVGD loss computation (루프 밖, 모든 파티클 동시에) ---
         if self.opt.repulsion_type == 'svgd':
-            score_gradients, sigma_t = self.guidance_sd.train_step_for_svgd_repulsion(images, step_ratio=step_ratio if self.opt.anneal_timestep else None) # [N, D_latent], [1]
-            
-            # 2. RBF kernel computation
-            rbf_kernel, rbf_kernel_grad = rbf_kernel_and_grad(features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type) # [N, N], [N, D_feature] 
-            
-            # 3. Attraction loss: 1/N * sum_j k(xj, xi) * ∇_xj log p(xj)
-            # rbf_kernel: [N, N] where rbf_kernel[i,j] = k(xj, xi)
-            # score_gradients: [N] where score_gradients[j] = ∇_xj log p(xj)
-            # Multiply kernel matrix with score gradients: [N, N] * [N] -> [N] (sum over j for each i)
-            # 1/D_latent
-            attraction_per_particle = (rbf_kernel * score_gradients.unsqueeze(0)).sum(dim=1) # [N]
-            attraction_loss = attraction_per_particle.mean() # [1]
-            
-            # # 3. Attraction loss: 1/N * sum_j k(xj, xi) * ∇_xj log p(xj)
-            # weighted_grad = rbf_kernel @ score_gradients  # [N, D_latent]
-            # attraction_loss = weighted_grad.norm(dim=1).mean()  # optional scalar for loss tracking
-            
-            # 4. Repulsion loss (same as before)
-            repulsion_loss = sigma_t * (rbf_kernel_grad * features).sum(dim=1).mean() # [N, D_feature] * [N, D_feature] -> [N] -> [1]
-            # [Question] should we divide by num_particles (mean)? in SVGD paper, they did divide by num_particles (mean)                              
+            # 1. Score gradients from SD guidance
+            score_grad, sigma_t = self.guidance_sd.train_step_for_svgd_repulsion(
+                images, 
+                step_ratio=step_ratio if self.opt.anneal_timestep else None
+            )  # score_grad: [N, D_latent]
 
-            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
+            # 2. Kernel & grad wrt xi (∑_j ∇_{xi} k(xi, xj))
+            K, G_wrt_xi = rbf_kernel_and_grad(
+                features, 
+                tau=self.opt.repulsion_tau, 
+                repulsion_type=self.opt.repulsion_type
+            )  # K:[N,N], G:[N,D_feature]   
+
+            # 3. Attraction: (1/N) * sum_i sum_j K[j,i] * score_grad[j]
+            #    K[i,j] = k(xi, xj) -> transpose해서 K[j,i]
+            attraction_loss = (K.t().unsqueeze(-1) * score_grad.unsqueeze(0)).sum(dim=1).mean()
+
+            # 4. Repulsion: (1/N) * sum_i sum_j ∇_{x_j}k(x_j,x_i)
+            #    대칭커널이면 ∇_{x_j}k(x_j,x_i) = -∇_{x_i}k(x_i,x_j)
+            rep_vec = -G_wrt_xi                           # [N,D]
+            repulsion_loss = rep_vec.norm(dim=1).mean()        # 스칼라
             scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
+            scaled_repulsion_loss = self.opt.lambda_repulsion * sigma_t * repulsion_loss
+            # 5. Total loss
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
-
 
         elif self.opt.repulsion_type == 'rlsd':
-            sds_loss, sigma_t = self.guidance_sd.train_step_for_rlsd_repulsion(images, step_ratio=step_ratio if self.opt.anneal_timestep else None) # [1]
+            sds_loss, sigma_t = self.guidance_sd.train_step_for_rlsd_repulsion(
+                images, 
+                step_ratio=step_ratio if self.opt.anneal_timestep else None
+            )
+            K, G_rlsd = rbf_kernel_and_grad(
+                features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type
+            )
             
-            # 2. RBF kernel gradient wrt features
-            rbf_kernel, rbf_kernel_log_grad = rbf_kernel_and_grad(features, tau=self.opt.repulsion_tau, repulsion_type=self.opt.repulsion_type) # [N, N], [N, D_feature] 
-            
-            # 3. Attraction loss (SDS) + 1/D_latent
-            attraction_loss = sds_loss # [1]
-            
-            # 4. Repulsion loss (Repulsion)
-            repulsion_loss = sigma_t * (rbf_kernel_log_grad * features).sum(dim=1).mean() # [N, D_feature] * [N, D_feature] -> [N] -> [1]
-            # repulsion_loss = sigma_t * torch.einsum('nd,nd->n', rbf_kernel_log_grad, features).mean()
-            
-            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
+            attraction_loss = sds_loss
+            repulsion_loss = G_rlsd.norm(dim=1).mean()
             scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
-            total_loss = scaled_attraction_loss - scaled_repulsion_loss
+            scaled_repulsion_loss = self.opt.lambda_repulsion * sigma_t *  repulsion_loss
             
+            total_loss = scaled_attraction_loss - scaled_repulsion_loss
+
         elif self.opt.repulsion_type == 'wo':
             # baseline
-            
             attraction_loss = self.guidance_sd.train_step_for_baseline(
                 images, step_ratio=step_ratio if self.opt.anneal_timestep else None
             )
             repulsion_loss = torch.tensor(0.0, device=images.device)
-            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
             scaled_attraction_loss = self.opt.lambda_sd * attraction_loss
+            scaled_repulsion_loss = self.opt.lambda_repulsion * repulsion_loss
+            
             total_loss = scaled_attraction_loss - scaled_repulsion_loss
-
+            
         else:
             raise ValueError(f"[ERROR] Invalid repulsion type: {self.opt.repulsion_type}")
 
@@ -341,9 +341,8 @@ class GUI:
                     fidelity=fidelity,
                     attraction_loss=attraction_loss,
                     repulsion_loss=repulsion_loss,
-                    sigma_t=sigma_t,
-                    scaled_repulsion_loss=scaled_repulsion_loss,
                     scaled_attraction_loss=scaled_attraction_loss,
+                    scaled_repulsion_loss=scaled_repulsion_loss,
                     total_loss=total_loss,
                     time=t,
                     memory_allocated_mb=memory_allocated,

--- a/metrics.py
+++ b/metrics.py
@@ -45,7 +45,7 @@ class MetricsCalculator:
         
             self.losses_csv_path = os.path.join(self.save_dir, "losses.csv")
             self.losses_csv_file = open(self.losses_csv_path, "w")
-            self.losses_csv_file.write("step,attraction_loss,repulsion_loss,sigma_t,scaled_attraction_loss,scaled_repulsion_loss,total_loss\n")
+            self.losses_csv_file.write("step,attraction_loss,repulsion_loss,scaled_attraction_loss,scaled_repulsion_loss,total_loss\n")
             
             self.efficiency_csv_path = os.path.join(self.save_dir, "efficiency.csv")
             self.efficiency_csv_file = open(self.efficiency_csv_path, "w")
@@ -62,9 +62,9 @@ class MetricsCalculator:
             self.metrics_csv_file.flush()
             
     @torch.no_grad()
-    def log_losses(self, step: int, attraction_loss: float, repulsion_loss: float, sigma_t: float, scaled_attraction_loss: float, scaled_repulsion_loss: float, total_loss: float):
+    def log_losses(self, step: int, attraction_loss: float, repulsion_loss: float, scaled_attraction_loss: float, scaled_repulsion_loss: float, total_loss: float):
         if self.losses_csv_file is not None:
-            self.losses_csv_file.write(f"{step},{attraction_loss},{repulsion_loss},{sigma_t},{scaled_attraction_loss},{scaled_repulsion_loss},{total_loss}\n")
+            self.losses_csv_file.write(f"{step},{attraction_loss},{repulsion_loss},{scaled_attraction_loss},{scaled_repulsion_loss},{total_loss}\n")
             self.losses_csv_file.flush()
             
     @torch.no_grad()
@@ -74,12 +74,12 @@ class MetricsCalculator:
             self.efficiency_csv_file.flush()
             
     @torch.no_grad()
-    def log_metrics(self, step: int, diversity: float, fidelity: float, attraction_loss: float, repulsion_loss: float, sigma_t: float, scaled_repulsion_loss: float, scaled_attraction_loss: float, total_loss: float, time: float, memory_allocated_mb: float = None, max_memory_allocated_mb: float = None):
+    def log_metrics(self, step: int, diversity: float, fidelity: float, attraction_loss: float, repulsion_loss: float, scaled_attraction_loss: float, scaled_repulsion_loss: float, total_loss: float, time: float, memory_allocated_mb: float = None, max_memory_allocated_mb: float = None):
         if self.opt is not None and self.save_dir is not None:
             if hasattr(self.opt, 'quantitative_metrics_interval') and step % self.opt.quantitative_metrics_interval == 0:
                 self.log_quantitative_metrics(step=step, diversity=diversity, fidelity=fidelity)
             if hasattr(self.opt, 'losses_interval') and step % self.opt.losses_interval == 0:
-                self.log_losses(step=step, attraction_loss=attraction_loss, repulsion_loss=repulsion_loss, sigma_t=sigma_t, scaled_attraction_loss=scaled_attraction_loss, scaled_repulsion_loss=scaled_repulsion_loss, total_loss=total_loss)
+                self.log_losses(step=step, attraction_loss=attraction_loss, repulsion_loss=repulsion_loss, scaled_attraction_loss=scaled_attraction_loss, scaled_repulsion_loss=scaled_repulsion_loss, total_loss=total_loss)
             if hasattr(self.opt, 'efficiency_interval') and step % self.opt.efficiency_interval == 0:
                 self.log_efficiency(step=step, time=time, memory_allocated_mb=memory_allocated_mb, max_memory_allocated_mb=max_memory_allocated_mb)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ accelerate
 transformers
 timm
 torchvision
+xformers
 
 # 3D mesh processing
 xatlas 

--- a/scripts/run_ours_debug.sh
+++ b/scripts/run_ours_debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=debug
-#SBATCH --partition=AMD7-A100-T
+#SBATCH --partition=gpgpu
 #SBATCH --gres=gpu:1
 #SBATCH --mail-type=FAIL
 #SBATCH --mail-user=sk2324@ic.ac.uk

--- a/scripts/run_ours_debug.sh
+++ b/scripts/run_ours_debug.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 #SBATCH --job-name=debug
-#SBATCH --partition=gpgpuB
+#SBATCH --partition=AMD7-A100-T
 #SBATCH --gres=gpu:1
-#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-type=FAIL
 #SBATCH --mail-user=sk2324@ic.ac.uk
 #SBATCH --output=outputs/%j/output.out
 #SBATCH --error=outputs/%j/error.err
+#SBATCH --mem=24G
 
 # SLURM batch script for DEBUG testing - Quick validation of main_ours.py
 # Usage: sbatch scripts/run_ours_debug.sh debug_quick_test [prompts...]

--- a/scripts/run_ours_rlsd.sh
+++ b/scripts/run_ours_rlsd.sh
@@ -52,7 +52,7 @@ PROMPT="a photo of a hamburger"
 ITER=1500
 
 REPULSION_TYPE="rlsd"
-LAMBDA_REPULSION=0.01
+LAMBDA_REPULSION=500
 REPULSION_TAU=0
 KERNEL_TYPE="rbf" # "rbf" or "laplacian" -- to be added
 

--- a/scripts/run_ours_svgd.sh
+++ b/scripts/run_ours_svgd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=ours_svgd
-#SBATCH --partition=gpgpuB
+#SBATCH --partition=gpgpu
 #SBATCH --gres=gpu:1
 #SBATCH --mail-type=END,FAIL
 #SBATCH --mail-user=sk2324@ic.ac.uk
@@ -52,7 +52,7 @@ PROMPT="a photo of a hamburger"
 ITER=1500
 
 REPULSION_TYPE="svgd"
-LAMBDA_REPULSION=100
+LAMBDA_REPULSION=500
 REPULSION_TAU=0
 KERNEL_TYPE="rbf" # "rbf" or "laplacian" -- to be added
 


### PR DESCRIPTION
Fix `UnboundLocalError` and `TypeError` in `train_step` by conditionally returning `sigma_t` and adjusting default `repulsion_type`.

The `train_step` method previously returned `(loss, sigma_t)` unconditionally, causing an `UnboundLocalError` when `repulsion_type` was 'wo' (where `sigma_t` is not defined) and `TypeError` for callers expecting a scalar loss. This PR ensures `sigma_t` is only returned when `repulsion_enabled` is true for 'svgd' or 'rlsd' types, otherwise a scalar loss is returned, restoring backward compatibility. The default `repulsion_type` is also set to 'wo'.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ef5ae32-6b94-42ca-a835-099e1c7cc7f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ef5ae32-6b94-42ca-a835-099e1c7cc7f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

